### PR TITLE
Close open issues #13, #14, #1

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -134,7 +134,7 @@ For each ADR found:
 3. If relevant, append to the project's CLAUDE.md under a `## Relevant ADRs` section (create the section if absent; never overwrite existing CLAUDE.md content)
 
 Injection format:
-```
+```markdown
 - **ADR-NNN: Title** (status) — summary. Applies because: [reason]
 ```
 
@@ -255,15 +255,15 @@ See `references/learnings-schema.md` for categorization logic and deduplication 
 
 ### 7d. Update ADRs with implementation consequences
 
-Check if any ADRs were injected into CLAUDE.md in Phase 4d. For each relevant ADR:
+Check if any ADRs were injected into CLAUDE.md in Phase 4c. For each relevant ADR:
 
 1. Ask: "Did implementation reveal anything this ADR didn't anticipate?"
 2. If yes, append a dated entry to the ADR's `## Consequences` section:
-   ```
+   ```markdown
    ### Implementation feedback — YYYY-MM-DD (<change-name>)
    <what was discovered>
    ```
-3. If an ADR is discovered to be wrong or outdated, change its status to `Status: Superseded` and note the reason inline
+3. If an ADR is discovered to be wrong or outdated, change its status to `**Status:** superseded` and note the reason inline
 
 If no ADRs were injected, skip this phase.
 
@@ -320,7 +320,7 @@ openspec archive <change-name>
 When ALL of the following are true, **merge immediately without asking the user:**
 
 - CI checks pass (build + tests green)
-- Code review (e.g., CodeRabbit) has no unresolved inline comments
+- Code review (e.g., CodeRabbit) has no unresolved blocking inline comments
 - No merge conflicts
 
 **Only pause for user input** when blocking review comments require design decisions that the agent cannot resolve autonomously.

--- a/references/adr-integration.md
+++ b/references/adr-integration.md
@@ -12,7 +12,7 @@ Scan these locations in the target project (in order):
 4. `ADR-*.md` (repo root)
 5. `adr-*.md` (repo root)
 
-If multiple locations contain ADRs, merge results from all of them. Deduplicate by ADR number.
+If multiple locations contain ADRs, merge results from all of them. Deduplicate primarily by ADR number. If ADR number is missing, deduplicate by normalized title (lowercase, punctuation-stripped) and file path.
 
 ## Expected ADR Format
 

--- a/references/worktree-isolation.md
+++ b/references/worktree-isolation.md
@@ -120,5 +120,5 @@ The following were investigated and confirmed safe in worktrees (no action neede
 
 - **Subagent `$PWD` inheritance:** `claude --dangerously-skip-permissions` subagents inherit the worktree's `$PWD`. `git rev-parse --show-toplevel` returns the worktree root.
 - **PID tracking:** Each worktree has its own `.loki/pids/` — no cross-contamination possible.
-- **`$PWD` in scripts:** All Wishloop scripts use `$PWD`-relative paths, which resolve correctly in worktrees.
+- **Script path scoping:** Wishloop scripts scope paths to the target project/worktree (via `cd "$PROJECT_DIR"` or `$PROJECT_DIR/...`), so `.loki` and repo file access remain worktree-correct.
 - **Git operations:** Worktrees have independent index files. `git add -A && git commit` scopes to worktree files only.


### PR DESCRIPTION
## Summary
- **#13 (bug):** Add auto-merge criteria to Phase 8 — agent merges immediately when CI passes, no blocking review comments, and no conflicts. Eliminates the "Want me to merge?" pause that broke autonomous flow.
- **#14 (enhancement):** ADR-aware agent workflow — Phase 4c discovers and injects relevant ADRs into CLAUDE.md before Loki runs, Phase 7d updates ADRs with implementation consequences. New reference doc at `references/adr-integration.md`.
- **#1 (research):** Researched all 7 Loki worktree edge cases — 5 confirmed safe, 1 known issue (dashboard port conflict), 1 user-dependent (resume directory). Updated `references/worktree-isolation.md` with findings.

Closes #13, closes #14, closes #1

## Test plan
- [ ] Verify Phase 8 auto-merge criteria section is correctly placed between Merge and Merge error handling
- [ ] Verify Phase 4c ADR discovery runs before 4d checkpoint commit
- [ ] Verify Phase 7d ADR update runs after 7c learnings update
- [ ] Verify `references/adr-integration.md` covers discovery, matching, injection, and update formats
- [ ] Verify `references/worktree-isolation.md` Known Pitfalls has 4 new items + Verified Safe section
- [ ] Verify reference table in SKILL.md includes new `adr-integration.md` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated Architecture Decision Record (ADR) discovery and injection into project context
  * Automated ADR consequence tracking based on implementation feedback
  * Auto-merge criteria documentation for streamlined workflows

* **Documentation**
  * Expanded ADR integration reference guide with discovery and update procedures
  * Enhanced worktree isolation documentation with known pitfalls and verified safe behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->