### PR TITLE
refactor: slim down Wishloop to delegate to Loki v6.75+

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -335,45 +335,29 @@ ITERATION=$(echo "$STATUS_JSON" | jq -r '.iteration')
 
 ### Wishloop Status Dashboard
 
-When checking session status, display this combined view showing what Wishloop configured and how Loki is progressing:
+Print a slim summary of Wishloop-only state (what we configured, our completion promise, the open PR), then delegate session detail to Loki:
 
 ```bash
-# Gather data
-STATUS_JSON=$(loki status --json 2>/dev/null)
-STATE_JSON=$(cat .wishloop/state.json 2>/dev/null)
-PROMISE=$(echo "$LOKI_COMPLETION_PROMISE" | fold -w 60)
+STATE_JSON=$(cat .wishloop/state.json 2>/dev/null || echo '{}')
 
-# Display
-echo "╔══════════════════════════════════════════════════════════╗"
-echo "║  WISHLOOP STATUS                                        ║"
-echo "╠══════════════════════════════════════════════════════════╣"
-echo "║  Change:  $(echo "$STATE_JSON" | jq -r '.change // "unknown"')"
-echo "║  Step:    $(echo "$STATE_JSON" | jq -r '.step // "unknown"')"
-echo "║  Started: $(echo "$STATE_JSON" | jq -r '.startedAt // "unknown"')"
-echo "╠══════════════════════════════════════════════════════════╣"
-echo "║  LOKI SESSION                                           ║"
-echo "║  Status:    $(echo "$STATUS_JSON" | jq -r '.status')"
-echo "║  Phase:     $(echo "$STATUS_JSON" | jq -r '.phase')"
-echo "║  Iteration: $(echo "$STATUS_JSON" | jq -r '.iteration')"
-echo "║  Tasks:     $(echo "$STATUS_JSON" | jq -r '.task_counts.completed')/$(echo "$STATUS_JSON" | jq -r '.task_counts.total') completed"
-echo "║  PID:       $(echo "$STATUS_JSON" | jq -r '.pid')"
-echo "╠══════════════════════════════════════════════════════════╣"
-echo "║  COMPLETION PROMISE                                     ║"
-echo "║  $PROMISE"
-echo "╠══════════════════════════════════════════════════════════╣"
-echo "║  PROPOSAL                                               ║"
-echo "║  $(head -1 "$PROPOSAL_PATH" 2>/dev/null || echo 'N/A')"
-echo "║  Exit criteria: $(grep -c '^\s*[-*]' <(sed -n '/## Exit Criteria/,/^## /p' "$PROPOSAL_PATH" 2>/dev/null) 2>/dev/null || echo '0') items"
-echo "╠══════════════════════════════════════════════════════════╣"
-echo "║  PR STATUS                                              ║"
-echo "║  $(gh pr list --json number,title,state --jq '.[0] | "#\(.number) \(.title) [\(.state)]"' 2>/dev/null || echo 'No open PR')"
-echo "╚══════════════════════════════════════════════════════════╝"
+echo "── Wishloop ──"
+echo "  Change:  $(echo "$STATE_JSON" | jq -r '.change // "unknown"')"
+echo "  Step:    $(echo "$STATE_JSON" | jq -r '.step // "unknown"')"
+echo "  Promise: $(echo "$LOKI_COMPLETION_PROMISE" | head -c 80)…"
+echo "  PR:      $(gh pr list --json number,title,state --jq '.[0] | "#\(.number) \(.title) [\(.state)]"' 2>/dev/null || echo 'no open PR')"
+echo ""
+
+# Delegate session detail to Loki — `loki status` / `loki dashboard` are the source of truth
+loki status 2>/dev/null || echo "(loki status unavailable)"
+# For a richer view, point the user at: loki dashboard open
 ```
 
 This dashboard is displayed:
 - At the start of each gardening check (Step 3.5)
 - When the user asks for status
 - In the cumulative summary at loop exit
+
+**Why slim?** Wishloop owns intake/session-mgmt state (change, step, completion promise). Loki owns session detail (phase, iteration, task counts, PID) and exposes a real dashboard via `loki dashboard start` / `loki dashboard --api` (v6.75.3). Don't reimplement what Loki ships natively.
 
 **Action directives from monitoring:**
 

--- a/scripts/drain.sh
+++ b/scripts/drain.sh
@@ -400,33 +400,21 @@ compose_completion_promise() {
   export LOKI_COMPLETION_PROMISE="$task_criteria. THEN: $process_bar"
 }
 
-# --- Helper: display Wishloop Status Dashboard ---
+# --- Helper: display Wishloop drain status ---
+# Wishloop owns drain-specific cumulative metrics; Loki owns session state.
+# We print our metrics inline, then delegate session detail to `loki status`.
 display_dashboard() {
-  local status_json
-  status_json=$(check_loki_status)
-  local state_json
-  state_json=$(cat "$STATE_FILE" 2>/dev/null || echo '{}')
-
-  echo "╔══════════════════════════════════════════════════════════╗"
-  echo "║  WISHLOOP DRAIN STATUS                                  ║"
-  echo "╠══════════════════════════════════════════════════════════╣"
-  printf "║  Iteration: %d / %d                                     ║\n" "$ITERATION" "$MAX_ITERATIONS"
-  printf "║  Label:     %-43s ║\n" "${LABEL_FILTER:-all}"
-  printf "║  Step:      %-43s ║\n" "$(echo "$state_json" | jq -r '.step // "unknown"')"
-  printf "║  Started:   %-43s ║\n" "$START_TIME"
-  echo "╠══════════════════════════════════════════════════════════╣"
-  echo "║  LOKI SESSION                                           ║"
-  printf "║  Status:    %-43s ║\n" "$(echo "$status_json" | jq -r '.status // "none"')"
-  printf "║  Phase:     %-43s ║\n" "$(echo "$status_json" | jq -r '.phase // "N/A"')"
-  printf "║  Iteration: %-43s ║\n" "$(echo "$status_json" | jq -r '.iteration // "N/A"')"
-  echo "╠══════════════════════════════════════════════════════════╣"
-  echo "║  CUMULATIVE                                             ║"
-  printf "║  Issues at start: %d | Resolved: %d | Filed: %d          ║\n" "$ISSUES_AT_START" "$ISSUES_RESOLVED" "$ISSUES_FILED"
-  printf "║  Sessions: %d | PRs merged: %d | Quick fixes: %d         ║\n" "$SESSIONS_LAUNCHED" "$PRS_MERGED" "$QUICK_FIXES"
-  echo "╠══════════════════════════════════════════════════════════╣"
-  echo "║  PR STATUS                                              ║"
-  printf "║  %-53s ║\n" "$(gh pr list --json number,title,state --jq '.[0] | "#\(.number) \(.title) [\(.state)]"' 2>/dev/null || echo 'No open PR')"
-  echo "╚══════════════════════════════════════════════════════════╝"
+  echo "── Wishloop drain status ──"
+  printf "  Iteration: %d / %d  |  Label: %s  |  Started: %s\n" \
+    "$ITERATION" "$MAX_ITERATIONS" "${LABEL_FILTER:-all}" "$START_TIME"
+  printf "  Cumulative: %d resolved, %d filed (start: %d) | sessions: %d, PRs: %d, quick: %d\n" \
+    "$ISSUES_RESOLVED" "$ISSUES_FILED" "$ISSUES_AT_START" \
+    "$SESSIONS_LAUNCHED" "$PRS_MERGED" "$QUICK_FIXES"
+  printf "  PR: %s\n" \
+    "$(gh pr list --json number,title,state --jq '.[0] | "#\(.number) \(.title) [\(.state)]"' 2>/dev/null || echo 'no open PR')"
+  echo ""
+  # Delegate session detail to Loki — its dashboard/status is the source of truth
+  loki status 2>/dev/null || echo "  (loki status unavailable)"
 }
 
 # --- Helper: print cumulative summary ---

--- a/scripts/enrich-proposal.sh
+++ b/scripts/enrich-proposal.sh
@@ -2,18 +2,11 @@
 # Auto-enrich a proposal with project context before Loki launch.
 # Usage: bash enrich-proposal.sh <project-dir> <proposal-path>
 #
-# Appends a ## Context (auto-generated) section to the proposal with:
-# - Relevant file paths + line numbers
-# - CLAUDE.md rules that apply
-# - Test file patterns
-# - Build/run/test commands
-# - Recent git history for relevant files
-# - Tech stack summary
+# Appends a ## Context (auto-generated) section. Codebase intelligence is
+# delegated to `loki code` (v6.75+); Wishloop only adds proposal-local context
+# (CLAUDE.md rules) and pointers to Loki commands the session will use.
 
 set -uo pipefail
-# Note: set -e is intentionally omitted. Many commands (grep, find, node) return
-# non-zero when they find no matches, which is expected during enrichment.
-# Each command handles its own errors via || true or conditional checks.
 
 PROJECT_DIR="${1:-.}"
 PROPOSAL="${2:-}"
@@ -26,193 +19,81 @@ fi
 
 cd "$PROJECT_DIR" || { echo "Error: Cannot access project directory: $PROJECT_DIR"; exit 1; }
 
-# Skip if already enriched
 if grep -q "## Context (auto-generated)" "$PROPOSAL" 2>/dev/null; then
   echo "Proposal already enriched. Skipping."
   exit 0
 fi
 
-# Extract key terms from proposal title and scope (first 20 lines)
+# Strip ANSI escape codes — `loki code` colorizes for terminal but Markdown won't render them.
+strip_ansi() { sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'; }
+
 TITLE=$(head -5 "$PROPOSAL" | grep -E "^#" | head -1 | sed 's/^#* *//')
-SCOPE_TERMS=$(head -20 "$PROPOSAL" | tr '[:upper:]' '[:lower:]' | \
-  grep -oE '[a-zA-Z_][a-zA-Z0-9_]{3,}' | \
-  sort -u | grep -vE '^(this|that|with|from|have|been|will|should|must|when|then|each|some|they|their|what|also|into|more|than|just|like|only|after|before|problem|solution|because|which|about|every|other|these|those|does|need|make|used|using|very|most|such|many|both|where|between|same|could|would|first|last|over|under|through|during|without|within|against|since|until|while|still)' | \
-  head -20 || true)
 
 echo ""
 echo "=== Enriching proposal: $TITLE ==="
 echo ""
 
-# Start building context section
 CONTEXT_FILE=$(mktemp)
-cat > "$CONTEXT_FILE" << 'HEADER'
+trap 'rm -f "$CONTEXT_FILE"' EXIT
 
-## Context (auto-generated)
+{
+  echo ""
+  echo "## Context (auto-generated)"
+  echo ""
+  echo "_Codebase intelligence delegated to \`loki code\` — Loki owns this output._"
+  echo ""
 
-HEADER
+  echo "### Codebase overview"
+  echo ""
+  echo '```'
+  loki code overview --silent 2>/dev/null | strip_ansi || echo "_loki code unavailable — run from a repo with Loki installed_"
+  echo '```'
+  echo ""
 
-# --- 1. Relevant file paths ---
-echo "### Files to modify" >> "$CONTEXT_FILE"
-echo "" >> "$CONTEXT_FILE"
+  echo "### Recent activity (hotspots)"
+  echo ""
+  echo '```'
+  loki code hotspots --top 5 2>/dev/null | strip_ansi || echo "_loki code unavailable_"
+  echo '```'
+  echo ""
 
-FOUND_FILES=false
-for term in $SCOPE_TERMS; do
-  # Search for the term in source files, show file:line
-  MATCHES=$(grep -rn --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" \
-    --include="*.py" --include="*.go" --include="*.rs" --include="*.rb" \
-    --include="*.java" --include="*.swift" --include="*.kt" \
-    -l "$term" . 2>/dev/null | grep -v node_modules | grep -v .git | head -5 || true)
-  if [ -n "$MATCHES" ]; then
-    for f in $MATCHES; do
-      LINE=$(grep -n "$term" "$f" 2>/dev/null | head -1 | cut -d: -f1)
-      echo "- \`${f}:${LINE}\` — matches \`$term\`" >> "$CONTEXT_FILE"
-      FOUND_FILES=true
-    done
-  fi
-done
-
-if [ "$FOUND_FILES" = false ]; then
-  echo "_No matching source files found for extracted terms._" >> "$CONTEXT_FILE"
-fi
-echo "" >> "$CONTEXT_FILE"
-
-# --- 2. CLAUDE.md rules ---
-if [ -f CLAUDE.md ]; then
-  echo "### Project rules (from CLAUDE.md)" >> "$CONTEXT_FILE"
-  echo "" >> "$CONTEXT_FILE"
-
-  # Extract Known Pitfalls and Mandatory Rules sections
-  RULES=$(awk '/^##.*[Pp]itfall|^##.*[Rr]ule|^##.*[Mm]andatory|^##.*[Cc]onvention/{found=1} found && /^##/ && !/[Pp]itfall|[Rr]ule|[Mm]andatory|[Cc]onvention/{found=0} found{print}' CLAUDE.md | head -30)
-
-  if [ -n "$RULES" ]; then
-    echo "$RULES" >> "$CONTEXT_FILE"
-  else
-    # Fallback: grep for lines with rule-like patterns
-    RULE_LINES=$(grep -iE '(always|never|must|do not|don.t|required|mandatory|forbidden)' CLAUDE.md | head -10 || true)
-    if [ -n "$RULE_LINES" ]; then
-      echo "$RULE_LINES" | while IFS= read -r line; do
-        echo "- $line" >> "$CONTEXT_FILE"
-      done
+  if [ -f CLAUDE.md ]; then
+    echo "### Project rules (from CLAUDE.md)"
+    echo ""
+    RULES=$(awk '/^##.*[Pp]itfall|^##.*[Rr]ule|^##.*[Mm]andatory|^##.*[Cc]onvention/{found=1} found && /^##/ && !/[Pp]itfall|[Rr]ule|[Mm]andatory|[Cc]onvention/{found=0} found{print}' CLAUDE.md | head -30)
+    if [ -n "$RULES" ]; then
+      echo "$RULES"
     else
-      echo "_No specific rules extracted from CLAUDE.md._" >> "$CONTEXT_FILE"
-    fi
-  fi
-  echo "" >> "$CONTEXT_FILE"
-fi
-
-# --- 3. Test file patterns ---
-echo "### Test patterns" >> "$CONTEXT_FILE"
-echo "" >> "$CONTEXT_FILE"
-
-# Find test files matching scope terms
-TEST_FILE=""
-for term in $SCOPE_TERMS; do
-  MATCH=$(find . -path ./node_modules -prune -o \( -name "*test*" -o -name "*spec*" \) -type f -print 2>/dev/null | \
-    grep -i "$term" | head -1 || true)
-  if [ -n "$MATCH" ]; then
-    TEST_FILE="$MATCH"
-    break
-  fi
-done
-
-# Fallback: find any test file
-if [ -z "$TEST_FILE" ]; then
-  TEST_FILE=$(find . -path ./node_modules -prune -o \( -name "*.test.*" -o -name "*.spec.*" -o -name "*_test.*" \) -type f -print 2>/dev/null | head -1 || true)
-fi
-
-if [ -n "$TEST_FILE" ]; then
-  TOTAL_TESTS=$(grep -c "it(\|test(\|func Test\|def test_" "$TEST_FILE" 2>/dev/null || echo "?")
-  echo "- File: \`$TEST_FILE\` ($TOTAL_TESTS tests)" >> "$CONTEXT_FILE"
-  echo '```' >> "$CONTEXT_FILE"
-  head -10 "$TEST_FILE" >> "$CONTEXT_FILE"
-  echo '```' >> "$CONTEXT_FILE"
-else
-  echo "_No test files found matching proposal scope._" >> "$CONTEXT_FILE"
-fi
-echo "" >> "$CONTEXT_FILE"
-
-# --- 4. Build commands ---
-echo "### Build commands" >> "$CONTEXT_FILE"
-echo "" >> "$CONTEXT_FILE"
-
-if [ -f package.json ]; then
-  echo '```bash' >> "$CONTEXT_FILE"
-  # Extract scripts section
-  node -e "const p=require('./package.json'); Object.entries(p.scripts||{}).forEach(([k,v])=>console.log(k+': '+v))" 2>/dev/null | \
-    grep -iE '(build|test|lint|check|start|dev)' | head -8 >> "$CONTEXT_FILE" || \
-    echo "# See package.json scripts" >> "$CONTEXT_FILE"
-  echo '```' >> "$CONTEXT_FILE"
-elif [ -f Makefile ]; then
-  echo '```bash' >> "$CONTEXT_FILE"
-  grep -E '^[a-zA-Z_-]+:' Makefile | head -8 | sed 's/:.*/ /' >> "$CONTEXT_FILE"
-  echo '```' >> "$CONTEXT_FILE"
-elif [ -f Cargo.toml ]; then
-  echo '```bash' >> "$CONTEXT_FILE"
-  echo "cargo build" >> "$CONTEXT_FILE"
-  echo "cargo test" >> "$CONTEXT_FILE"
-  echo '```' >> "$CONTEXT_FILE"
-elif [ -f go.mod ]; then
-  echo '```bash' >> "$CONTEXT_FILE"
-  echo "go build ./..." >> "$CONTEXT_FILE"
-  echo "go test ./..." >> "$CONTEXT_FILE"
-  echo '```' >> "$CONTEXT_FILE"
-elif [ -f pyproject.toml ]; then
-  echo '```bash' >> "$CONTEXT_FILE"
-  echo "pip install -e ." >> "$CONTEXT_FILE"
-  echo "pytest" >> "$CONTEXT_FILE"
-  echo '```' >> "$CONTEXT_FILE"
-else
-  echo "_No build system detected._" >> "$CONTEXT_FILE"
-fi
-echo "" >> "$CONTEXT_FILE"
-
-# --- 5. Recent git history for relevant files ---
-echo "### Recent git history" >> "$CONTEXT_FILE"
-echo "" >> "$CONTEXT_FILE"
-
-if [ "$FOUND_FILES" = true ]; then
-  # Get unique files from the matches (first 5)
-  for term in $SCOPE_TERMS; do
-    FILE=$(grep -rl --include="*.ts" --include="*.tsx" --include="*.js" --include="*.py" --include="*.go" \
-      "$term" . 2>/dev/null | grep -v node_modules | head -1 || true)
-    if [ -n "$FILE" ]; then
-      HISTORY=$(git log --oneline -3 -- "$FILE" 2>/dev/null)
-      if [ -n "$HISTORY" ]; then
-        echo "**$FILE:**" >> "$CONTEXT_FILE"
-        echo '```' >> "$CONTEXT_FILE"
-        echo "$HISTORY" >> "$CONTEXT_FILE"
-        echo '```' >> "$CONTEXT_FILE"
+      RULE_LINES=$(grep -iE '(always|never|must|do not|don.t|required|mandatory|forbidden)' CLAUDE.md | head -10 || true)
+      if [ -n "$RULE_LINES" ]; then
+        echo "$RULE_LINES" | sed 's/^/- /'
+      else
+        echo "_No specific rules extracted from CLAUDE.md._"
       fi
-      break  # Just show one file's history to keep it concise
     fi
-  done
-else
-  echo "_No relevant files to show history for._" >> "$CONTEXT_FILE"
-fi
-echo "" >> "$CONTEXT_FILE"
+    echo ""
+  fi
 
-# --- 6. Tech stack summary ---
-echo "### Tech stack" >> "$CONTEXT_FILE"
-echo "" >> "$CONTEXT_FILE"
+  echo "### Test patterns"
+  echo ""
+  echo "Loki discovers tests during its session. To inspect manually:"
+  echo ""
+  echo '```bash'
+  echo "loki code symbols 'test|spec|describe|def test_'"
+  echo '```'
+  echo ""
 
-if [ -f package.json ]; then
-  echo "**Dependencies:**" >> "$CONTEXT_FILE"
-  node -e "const p=require('./package.json'); const d={...p.dependencies,...p.devDependencies}; Object.keys(d).sort().slice(0,15).forEach(k=>console.log('- '+k+': '+d[k]))" 2>/dev/null >> "$CONTEXT_FILE" || \
-    echo "_Could not parse package.json_" >> "$CONTEXT_FILE"
-elif [ -f go.mod ]; then
-  echo "**Go modules:**" >> "$CONTEXT_FILE"
-  grep -E '^\t' go.mod 2>/dev/null | head -10 | sed 's/^\t/- /' >> "$CONTEXT_FILE"
-elif [ -f Cargo.toml ]; then
-  echo "**Cargo dependencies:**" >> "$CONTEXT_FILE"
-  awk '/\[dependencies\]/{found=1;next} /^\[/{found=0} found && NF{print "- "$0}' Cargo.toml | head -10 >> "$CONTEXT_FILE"
-elif [ -f pyproject.toml ]; then
-  echo "**Python dependencies:**" >> "$CONTEXT_FILE"
-  awk '/dependencies/{found=1;next} /^\[/{found=0} found && NF{print "- "$0}' pyproject.toml | head -10 >> "$CONTEXT_FILE"
-fi
+  echo "### Build commands"
+  echo ""
+  echo "Loki reads build/test/lint commands natively from \`package.json\` / \`Makefile\` / \`pyproject.toml\` / \`Cargo.toml\` / \`go.mod\`. For an explicit summary:"
+  echo ""
+  echo '```bash'
+  echo "loki onboard       # generates/refreshes CLAUDE.md with build commands"
+  echo '```'
+  echo ""
+} >> "$CONTEXT_FILE"
 
-# --- Append to proposal ---
 cat "$CONTEXT_FILE" >> "$PROPOSAL"
-rm -f "$CONTEXT_FILE"
 
 echo ""
 echo "Proposal enriched successfully."


### PR DESCRIPTION
## Summary
- Honors the "thin layer" principle: where Loki v6.75+ ships native features (`loki code overview/hotspots`, `loki status`, `loki dashboard`), Wishloop should call them rather than reimplementing.
- **`scripts/enrich-proposal.sh`**: ~200 lines of bespoke grep/awk for files/tests/build commands/git history → calls to `loki code overview --silent` + `loki code hotspots --top 5`. CLAUDE.md rule extraction stays (Loki has no equivalent). Section headers preserved.
- **`scripts/drain.sh` `display_dashboard`**: 25-line ASCII art box → 3-line Wishloop-owned summary (drain cumulative metrics) followed by `loki status`. Loki owns session state.
- **`SKILL.md` Wishloop Status Dashboard**: same pattern — slim Wishloop summary, then delegate to `loki status` and point at `loki dashboard open` for the richer view (v6.75.3 added `--api`).

## Why
Audit against Loki v6.75.3 found Wishloop and Loki are well-aligned (no must-fix work) but two surfaces had drifted from the "thin layer" rule by reimplementing things Loki now ships natively. Net diff: **+90, -237 lines**.

## What's NOT changed
- No CLI invocations renamed
- No env vars changed (`LOKI_COMPLETION_PROMISE`, `LOKI_GITHUB_PR`, `LOKI_COUNCIL_ENABLED`, etc. all still set)
- Section headers in enriched proposals preserved (`### Build commands`, `### Test patterns`, `### Project rules`)
- Function name `display_dashboard` preserved

## Test plan
- [x] `bash tests/test-scripts.sh` — all 151 tests pass
- [x] Smoke test: `enrich-proposal.sh` against a fresh git repo produces a valid proposal with all expected sections
- [x] `bash -n` syntax check on both scripts
- [ ] CodeRabbit review
- [ ] Verify against a real drain run (will do post-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated status dashboard behavior and responsibility split.

* **Refactor**
  * Simplified status dashboard output to display Wishloop configuration and first open PR separately from Loki session details.
  * Refactored dashboard helper for cleaner inline text output.
  * Streamlined proposal context enrichment pipeline with updated output generation.

* **Chores**
  * Made project directory configurable via environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->