### PR TITLE
config: re-add LOKI_AUTONOMY_MODE=checkpoint to loki.env

### DIFF
--- a/.wishloop/loki.env
+++ b/.wishloop/loki.env
@@ -6,6 +6,9 @@ LOKI_GITHUB_SYNC=true
 LOKI_COUNCIL_ENABLED=true
 LOKI_AUDIT_LOG=true
 
+# CRITICAL: checkpoint mode prevents "NEVER stop" contradicting the completion promise
+LOKI_AUTONOMY_MODE=checkpoint
+
 # Process bar — always appended to task-specific exit criteria
 # Wishloop composes the full promise: <task exit criteria> + PROCESS_BAR
 WISHLOOP_PROCESS_BAR="PR created, all CI checks passing, CodeRabbit review received, all comments fixed and responded to, no unresolved review threads"


### PR DESCRIPTION
## Summary
Re-adds `LOKI_AUTONOMY_MODE=checkpoint` to `.wishloop/loki.env`. This setting tells Loki's autonomy loop to honor the completion promise as a stopping condition.

## Why it matters
Wishloop's process-bar promise is `PR created → CI passing → CodeRabbit clean → merged`. Without `checkpoint` mode, Loki's default "NEVER stop" autonomy contradicts the promise — sessions run past their stated completion point.

## What changed
```diff
+# CRITICAL: checkpoint mode prevents "NEVER stop" contradicting the completion promise
+LOKI_AUTONOMY_MODE=checkpoint
```

The comment is intentional — it documents why the line exists, so it isn't silently removed during future cleanup.

## Test plan
- [x] `.wishloop/loki.env` is sourced before every Loki session via [SKILL.md Step 3](SKILL.md)
- [ ] Smoke test: launch a Loki session and verify autonomy honors `LOKI_COMPLETION_PROMISE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)